### PR TITLE
Fixed broken links in Documentation README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ my_classifier/
 
 ## Documentation
 
-For detailed documentation, visit our [documentation site](https://github.com/jxnl/instructor-classify/docs) or run:
+For detailed documentation, visit our [documentation site](https://jxnl.github.io/instructor-classify/) or run:
 
 ```bash
 mkdocs serve
@@ -227,7 +227,7 @@ mkdocs serve
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! See [CONTRIBUTING.md](docs/contributing.md) for guidelines.
 
 ## Good first Issue:
 


### PR DESCRIPTION
Fixes #3 
- Changed site link to correct link
- Changed path to CONTRIBUTING.md to correct path
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken links in `readme.md` for documentation site and `CONTRIBUTING.md`.
> 
>   - **Documentation Links**:
>     - Updated documentation site link in `readme.md` to `https://jxnl.github.io/instructor-classify/`.
>     - Corrected path to `CONTRIBUTING.md` in `readme.md` to `docs/contributing.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor-classify&utm_source=github&utm_medium=referral)<sup> for 8b30b19a0375ac066f957cabbc9be79645fe5285. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->