### PR TITLE
Fix instructor-classify init cli bug

### DIFF
--- a/instructor_classify/cli.py
+++ b/instructor_classify/cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import shutil
 import sys
 import os
+from typing_extensions import Annotated
 
 # Add parent directory to path for imports
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -21,11 +22,9 @@ def get_template_path() -> Path:
 
 @app.command("init")
 def init(
-    project_name: str = typer.Option(
-        ...,
-        prompt="What would you like to name your project directory?",
-        help="Name of the project directory to create"
-    )
+    project_name: Annotated[
+        str, typer.Argument(help="Name of the project directory to create")
+    ],
 ):
     """Initialize a new classifier project."""
     project_dir = Path(project_name)


### PR DESCRIPTION
- The documentation states that we can init a project with:
`instruct-classify init my_classifier`
- However, it doesn't work since project_name is an option instead of an argument.
- This closes #16

## Changes
- Update `project_name` from typer option to typer argument.
- This enables us to use the current API mentioned in the documentation for initializing a project.

## Testing
- `instruct-classify init my_classifier` creates the `my_classifier` directory with example prompt, classifier, etc.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CLI bug by changing `project_name` from option to argument in `init` command, aligning with documentation.
> 
>   - **Behavior**:
>     - Fixes bug in `init` command in `cli.py` by changing `project_name` from a `typer.Option` to a `typer.Argument`.
>     - Allows `instruct-classify init my_classifier` to create `my_classifier` directory as documented.
>   - **Testing**:
>     - Verified `instruct-classify init my_classifier` creates directory with example files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor-classify&utm_source=github&utm_medium=referral)<sup> for 329342d1f16f41aaddf329fa1aafa4249c92070a. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->